### PR TITLE
Allow country to update flag if no value has been set

### DIFF
--- a/source/Input.js
+++ b/source/Input.js
@@ -518,7 +518,7 @@ export default class PhoneNumberInput extends PureComponent
 		// Because if the user has already started inputting a phone number
 		// then he's okay with no country being selected at all ("International")
 		// and doesn't want to be disturbed, doesn't want his input to be screwed, etc.
-		if (new_default_country !== old_default_country && !country && !value && !new_value)
+		if (new_default_country !== old_default_country && !value && !new_value)
 		{
 			return {
 				...new_state,


### PR DESCRIPTION
As long as there is no phone number entered, `props.country` should update `state.country`.

Example use case:
I have a separate country input field that when changed should update the country flag on the `<Phone>` component (as long as user has not entered a phone number yet), but this behaviour has been broken since updating to the current version of this library.