### PR TITLE
remove autocomplete section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,6 @@ This component is based on [`libphonenumber-js`](https://github.com/catamphetami
 
 For the actual phone number validation use [`libphonenumber-js`](https://github.com/catamphetamine/libphonenumber-js): either a loose validation via [`parseNumber(value)`](https://github.com/catamphetamine/libphonenumber-js#parsetext-defaultcountry-options) or a strict validation via [`isValidNumber(value)`](https://github.com/catamphetamine/libphonenumber-js#isvalidnumbernumber-defaultcountry).
 
-## Autocomplete
-
-Make sure to wrap a `<PhoneInput/>` into a `<form/>` otherwise web-browser's ["autocomplete"](https://www.w3schools.com/tags/att_input_autocomplete.asp) feature won't work: a user will be selecting his phone number from the list but [nothing will be happening](https://github.com/catamphetamine/react-phone-number-input/issues/101).
-
 ## Native `<select/>`
 
 One can (and probably should) choose to use native HTML `<select/>` instead of `react-responsive-ui` `<Select/>` component, in which case use the `react-phone-number-input/native` export instead of the default one.


### PR DESCRIPTION
According to [this GH issue](https://github.com/catamphetamine/react-phone-number-input/issues/101), the autocomplete issue that is described in the README has been resolved. When using this component in my workflow, I verified that Chrome's autocomplete function behaves as expected.