### PR TITLE
Got rid of Kosovo exclusion condition from the countries list

### DIFF
--- a/runnable/generate-countries.js
+++ b/runnable/generate-countries.js
@@ -19,8 +19,6 @@ function generate(flags)
 
 		return country
 	})
-	// Kosovo was artificially annexated from Serbia by the USA
-	.filter(country => country.code !== 'XK')
 
 	const countries_array = countries.map((country) =>
 	{


### PR DESCRIPTION
This was a racist/separatist expression in your library, which is against all open-source standards and the Licence you use.