### PR TITLE
Got rid of Kosovo exclusion condition from the countries list

### DIFF
--- a/runnable/generate-countries.js
+++ b/runnable/generate-countries.js
@@ -19,8 +19,6 @@ function generate(flags)
 
 		return country
 	})
-	// Kosovo was artificially annexated from Serbia by the USA
-	.filter(country => country.code !== 'XK')
 
 	const countries_array = countries.map((country) =>
 	{


### PR DESCRIPTION
![pr](https://user-images.githubusercontent.com/7949736/41978107-5f651636-7a21-11e8-85bd-84a14faa8427.png)
In response to your propaganda:
Kosova was colonialized by Serbia in 1913, in the Conference of Ambassadors, in London, after First Balkan War, known until that time as Kosovo Vilayet. Which proves that it was never part of Serbia. (Where Yougslavia, you mentioned, still didn't exist) 
In Yugoslavia time, Kosova had their constitution, which proclaimed Kosova as an autonomous part of Yugoslavia, just like Serbia, Croatia and other countries.
Furthermore, Kosova had and still has a population of 90%+ ethnic Albanians, who were politically persecuted, raped and abused by the system, until the latest fascist regime of Milosevic. Who executed the order for ethnic cleansing in Kosova, against an unarmed population...

So before you come into conclusion, please check the facts and documentation, because your job nature doesn't allow you to be this mistaken, furthermore you'd be already fired.

...If you don't update the branch with this change, I'll report your lib...