### PR TITLE
Error when you use onCountryChange property without country property

### DIFF
--- a/source/PhoneInput.js
+++ b/source/PhoneInput.js
@@ -537,7 +537,7 @@ export default class PhoneNumberInput extends PureComponent
 		const { country: selectedCountry } = this.state
 
 		if (onCountryChange) {
-			if (!this.isCountrySupportedWithError(country)) {
+			if (!country || !this.isCountrySupportedWithError(country)) {
 				country = undefined
 			}
 			if (selectedCountry !== country) {


### PR DESCRIPTION
When you use `PhoneInput` with `onCountryChange` property and without `country` property, it throws an error to the console:
> Country not found: undefined

Sandbox with demo: https://codesandbox.io/s/formik-reactphonenumberinput-gtmxr?fontsize=14

This PR aims to fix this