### PR TITLE
Remove isRequired from selectArrowComponent PropType

### DIFF
--- a/source/CountrySelectNative.js
+++ b/source/CountrySelectNative.js
@@ -30,7 +30,7 @@ export default class CountrySelectNative extends Component
 		tabIndex : PropTypes.number,
 
 		// Select arrow component.
-		selectArrowComponent : PropTypes.elementType.isRequired,
+		selectArrowComponent : PropTypes.elementType,
 
 		// Toggles the `--focus` CSS class.
 		// https://github.com/catamphetamine/react-phone-number-input/issues/189


### PR DESCRIPTION
Doesn't make sense to be required if it's a defaultProp, and it's causing the following error: Cannot read property 'isRequired' of undefined