### PR TITLE
Remove duplicate Div with class "PhoneInput"

### DIFF
--- a/source/PhoneInputWithCountry.js
+++ b/source/PhoneInputWithCountry.js
@@ -442,44 +442,40 @@ class PhoneNumberInput_ extends React.PureComponent {
 					'PhoneInput--focus': isFocused
 				})}>
 
-				{/* Country `<select/>` and phone number `<input/>` */}
-				<div className="PhoneInput">
+				{/* Country `<select/>` */}
+				<CountrySelectComponent
+					name={name ? `${name}Country` : undefined}
+					aria-label={labels.country}
+					{...countrySelectProps}
+					value={country}
+					options={countrySelectOptions}
+					onChange={this.onCountryChange}
+					onFocus={this._onFocus}
+					onBlur={this._onBlur}
+					disabled={disabled}
+					iconComponent={this.CountryIcon}/>
 
-					{/* Country `<select/>` */}
-					<CountrySelectComponent
-						name={name ? `${name}Country` : undefined}
-						aria-label={labels.country}
-						{...countrySelectProps}
-						value={country}
-						options={countrySelectOptions}
-						onChange={this.onCountryChange}
-						onFocus={this._onFocus}
-						onBlur={this._onBlur}
-						disabled={disabled}
-						iconComponent={this.CountryIcon}/>
-
-					{/* Phone number `<input/>` */}
-					<InputComponent
-						ref={this.getInputRef()}
-						type="tel"
-						autoComplete={autoComplete}
-						{...numberInputProps}
-						{...rest}
-						name={name}
-						metadata={metadata}
-						country={country}
-						value={parsedInput || ''}
-						onChange={this.onChange}
-						onFocus={this.onFocus}
-						onBlur={this.onBlur}
-						disabled={disabled}
-						inputComponent={inputComponent}
-						className={classNames(
-							'PhoneInputInput',
-							numberInputProps && numberInputProps.className,
-							rest.className
-						)}/>
-				</div>
+				{/* Phone number `<input/>` */}
+				<InputComponent
+					ref={this.getInputRef()}
+					type="tel"
+					autoComplete={autoComplete}
+					{...numberInputProps}
+					{...rest}
+					name={name}
+					metadata={metadata}
+					country={country}
+					value={parsedInput || ''}
+					onChange={this.onChange}
+					onFocus={this.onFocus}
+					onBlur={this.onBlur}
+					disabled={disabled}
+					inputComponent={inputComponent}
+					className={classNames(
+						'PhoneInputInput',
+						numberInputProps && numberInputProps.className,
+						rest.className
+					)}/>
 			</div>
 		)
 	}


### PR DESCRIPTION
v3 nests two ``divs`` with the class ``PhoneInput`` as can be seen on the [examples](http://catamphetamine.github.io/react-phone-number-input/) and below:

https://github.com/catamphetamine/react-phone-number-input/blob/4cde3938ac9a877657b51efe23282e3e6dfc4dae/source/PhoneInputWithCountry.js#L439-L446

This PR removes one.