### PR TITLE
Gracefully handle the situation where a translation is missing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,10 @@ JSON.stringify(
   '\t'
 )
 ````
+
+Please note that these lists miss Ascension Island (`AC`) and Tristan da Cunha (`TA`).
+They will need to be added manually.
+
 </details>
 
 ####

--- a/source/phoneInputHelpers.js
+++ b/source/phoneInputHelpers.js
@@ -438,7 +438,7 @@ export function compare_strings(a, b) {
   // `localeCompare()` is available in latest Node.js versions.
   /* istanbul ignore else */
   if (String.prototype.localeCompare) {
-    return a.localeCompare(b);
+    return (a || b) ? (!a ? 1 : !b ? -1 : a.localeCompare(b)) : 0;
   }
   /* istanbul ignore next */
   return a < b ? -1 : (a > b ? 1 : 0);


### PR DESCRIPTION
Currently, if the provided translations are missing some entries, the component will crash with the error:
`Cannot read property 'localeCompare' of undefined`.

This change will gracefully handle this situation and move the missing codes to the end of the list.