### PR TITLE
Update <img> tag for accessibility

### DIFF
--- a/source/Flag.js
+++ b/source/Flag.js
@@ -20,7 +20,6 @@ export default function FlagComponent({
 			{...rest}
 			alt={countryName}
 			role="presentation"
-			aria-hidden="true"
 			src={flagUrl.replace('{XX}', country).replace('{xx}', country.toLowerCase())}/>
 	)
 }

--- a/source/Flag.js
+++ b/source/Flag.js
@@ -19,6 +19,8 @@ export default function FlagComponent({
 		<img
 			{...rest}
 			alt={countryName}
+			role="presentation"
+			aria-hidden="true"
 			src={flagUrl.replace('{XX}', country).replace('{xx}', country.toLowerCase())}/>
 	)
 }


### PR DESCRIPTION
Add `role="presentation"` and `aria-hidden="true"` to flag `<img\>` tag for accessibility.

This is to satisfy [Web Content Accessibility Guidelines Success Criterion 1.3.1: Info and Relationships](https://www.w3.org/TR/WCAG21/#info-and-relationships).