### PR TITLE
fix: add generated TypeScript definitions for locales

### DIFF
--- a/locale/ar.d.ts
+++ b/locale/ar.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/ar.json.d.ts
+++ b/locale/ar.json.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/cz.d.ts
+++ b/locale/cz.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/cz.json.d.ts
+++ b/locale/cz.json.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/de.d.ts
+++ b/locale/de.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/de.json.d.ts
+++ b/locale/de.json.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/el.d.ts
+++ b/locale/el.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/el.json.d.ts
+++ b/locale/el.json.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/en.d.ts
+++ b/locale/en.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/en.json.d.ts
+++ b/locale/en.json.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/es.d.ts
+++ b/locale/es.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/es.json.d.ts
+++ b/locale/es.json.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/fi.d.ts
+++ b/locale/fi.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/fi.json.d.ts
+++ b/locale/fi.json.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/fr.d.ts
+++ b/locale/fr.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/fr.json.d.ts
+++ b/locale/fr.json.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/he.d.ts
+++ b/locale/he.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/he.json.d.ts
+++ b/locale/he.json.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/it.d.ts
+++ b/locale/it.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/it.json.d.ts
+++ b/locale/it.json.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/nb.d.ts
+++ b/locale/nb.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/nb.json.d.ts
+++ b/locale/nb.json.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/nl.d.ts
+++ b/locale/nl.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/nl.json.d.ts
+++ b/locale/nl.json.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/pl.d.ts
+++ b/locale/pl.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/pl.json.d.ts
+++ b/locale/pl.json.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/pt-BR.d.ts
+++ b/locale/pt-BR.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/pt-BR.json.d.ts
+++ b/locale/pt-BR.json.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/pt.d.ts
+++ b/locale/pt.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/pt.json.d.ts
+++ b/locale/pt.json.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/ru.d.ts
+++ b/locale/ru.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/ru.json.d.ts
+++ b/locale/ru.json.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/sk.d.ts
+++ b/locale/sk.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/sk.json.d.ts
+++ b/locale/sk.json.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/sv.d.ts
+++ b/locale/sv.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/sv.json.d.ts
+++ b/locale/sv.json.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/tr.d.ts
+++ b/locale/tr.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/tr.json.d.ts
+++ b/locale/tr.json.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/ua.d.ts
+++ b/locale/ua.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/ua.json.d.ts
+++ b/locale/ua.json.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/vi.d.ts
+++ b/locale/vi.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/locale/vi.json.d.ts
+++ b/locale/vi.json.d.ts
@@ -1,0 +1,3 @@
+type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale

--- a/runnable/generate-locale-exports.js
+++ b/runnable/generate-locale-exports.js
@@ -1,10 +1,12 @@
 import fs from 'fs'
+import fsPromises from 'fs/promises'
 import path from 'path'
 
 // Stupid Node.js can't even `import` JSON files.
 // https://stackoverflow.com/questions/72348042/typeerror-err-unknown-file-extension-unknown-file-extension-json-for-node
 // Using a `*.json.js` duplicate file workaround.
 createLocaleJsonJsFiles(getAllLocales())
+await createLocaleDTsFiles(getAllLocales())
 
 addLocaleExports(getAllLocales())
 
@@ -63,4 +65,18 @@ function createLocaleJsonJsFiles(locales) {
 		const localeData = readJsonFromFile(`./locale/${locale}.json`)
 		fs.writeFileSync(`./locale/${locale}.json.js`, 'export default ' + JSON.stringify(localeData, null, 2), 'utf8')
 	}
+}
+
+async function createLocaleDTsFiles(locales) {
+	const dTs = `type Locale = { [K in keyof import('../index').Labels]: string }
+const Locale: Locale
+export default Locale
+`;
+
+  return Promise.all([
+    locales.flatMap((locale) => [
+      fsPromises.writeFile(`./locale/${locale}.d.ts`, dTs),
+      fsPromises.writeFile(`./locale/${locale}.json.d.ts`, dTs),
+    ]),
+  ]);
 }


### PR DESCRIPTION
This PR adds a new function to `runnable/generate-locale-exports.js` that outputs a stub type definition file for every locale. The emitted files are auto-discovered by TSC because they're the same name.

For my use-case this fixes importing locales, but not sure if the exact type itself is 100% correct.

What do you think @catamphetamine?