### PR TITLE
fix: react-native PhoneInput props "metadata" is not required

### DIFF
--- a/source/react-native/PhoneInput.js
+++ b/source/react-native/PhoneInput.js
@@ -39,7 +39,7 @@ export function createPhoneInput(defaultMetadata) {
 		/**
 		 * `libphonenumber-js` metadata.
 		 */
-		metadata: metadataType.isRequired
+		metadata: metadataType
 	}
 
 	return PhoneInput


### PR DESCRIPTION
When using the library, the following warning is displayed in react-native: 

```
Warning: Failed prop type: The prop `metadata` is marked as required in `ForwardRef(PhoneInput)`, but its value is `undefined`.
    at PhoneInput
```

The `metadata` prop is set by default to `defaultMetadata`