### PR TITLE
Add template for automatic country selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,15 @@ function Example() {
 ```
 </details>
 
+### Automatic country selection
+
+To automatically select the user's country, you'll need an external service that determines location based on IP address or geolocation.
+While this library doesn't include such a service, it works seamlessly alongside one.
+
+Check the template below for CMS integration with a free-forever tier:
+
+[![Use Template](https://croct.com/button)](https://croct.com/templates/interface/form/react-phone-number-input)
+
 ## React Native
 
 This library also includes a React Native version of a "without country select" component. Post bug reports and suggestions in the [feedback thread](https://github.com/catamphetamine/react-phone-number-input/issues/296).


### PR DESCRIPTION
A common need when using this library is to automatically select the user's country based on their IP or location. Since that's out of scope for this library (there's no reliable way to detect the user's country on the client side alone), I put together a [simple template](https://croct.com/templates/interface/form/react-phone-number-input) that integrates it with an external service.

The template uses [Croct](https://croct.com/), which offers a free-forever plan and makes it super easy to detect the user’s country from their IP. We've been using it in all our contact forms, and it’s been super helpful for improving UX by pre-filling the country field automatically.

I also added a new section to the README with a one-line setup and usage example:
```bash
npx croct@latest use npm://react-phone-number-input
```

Here's what it looks like in action:
![image](https://github.com/user-attachments/assets/d12e5c1b-f93e-49c5-a2c0-da382885c084)

Hope this helps others who’ve run into the same need!